### PR TITLE
Refactor: Update schedule view and icons

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { Calendar, Clock, User, Edit, EyeOff, Plus, Save, UserPlus, Users, LayoutDashboard, ChevronsRight, X, CheckCircle, Send, Wrench } from 'lucide-react';
+import { Calendar, Clock, User, Edit, Eye, EyeOff, Plus, Save, UserPlus, Users, LayoutDashboard, ChevronsRight, X, CheckCircle, Send, Wrench } from 'lucide-react';
 
 import GlobalLoader from './components/GlobalLoader';
 import NotificationToast from './components/NotificationToast';
@@ -192,7 +192,9 @@ function App() {
                             <div className="schedule-card-header">
                               <div className="schedule-card-title"><User size={20} /> <strong>{psi.nome}</strong> (ID: {psi.psicologa_id})</div>
                               <div className="schedule-actions">
-                                <button onClick={() => toggleScheduleExpansion(psi.psicologa_id)} className="btn btn-ghost btn-small btn-icon" title={expandedSchedules.includes(psi.psicologa_id) ? 'Recolher' : 'Ver Horários'}><EyeOff size={16} /></button>
+                                <button onClick={() => toggleScheduleExpansion(psi.psicologa_id)} className="btn btn-ghost btn-small btn-icon" title={expandedSchedules.includes(psi.psicologa_id) ? 'Recolher' : 'Ver Horários'}>
+                                  {expandedSchedules.includes(psi.psicologa_id) ? <Eye size={16} /> : <EyeOff size={16} />}
+                                </button>
                                 <button onClick={() => handleLoadForEdit(psi)} className="btn btn-secondary btn-small"><Edit size={16} /> Editar</button>
                               </div>
                             </div>

--- a/src/components/TotalScheduleView.jsx
+++ b/src/components/TotalScheduleView.jsx
@@ -14,11 +14,11 @@ const TotalScheduleView = ({ schedules }) => {
     const totalSchedule = useMemo(() => {
         const aggregated = {};
         DIAS_SEMANA.forEach(dia => { aggregated[dia.key] = {}; HORAS_TRABALHO.forEach(hora => { aggregated[dia.key][hora] = []; }); });
-        schedules.forEach(psi => { DIAS_SEMANA.forEach(dia => { if (psi.horarios_disponiveis && psi.horarios_disponiveis[dia.key]) { psi.horarios_disponiveis[dia.key].forEach(hora => { if (aggregated[dia.key][hora]) aggregated[dia.key][hora].push(psi.psicologa_id); }); } }); });
+        schedules.forEach(psi => { DIAS_SEMANA.forEach(dia => { if (psi.horarios_disponiveis && psi.horarios_disponiveis[dia.key]) { psi.horarios_disponiveis[dia.key].forEach(hora => { if (aggregated[dia.key][hora]) aggregated[dia.key][hora].push({ id: psi.psicologa_id, nome: psi.nome }); }); } }); });
         return aggregated;
     }, [schedules]);
 
-    return (<div className="total-schedule-grid">{DIAS_SEMANA.map(dia => (<div key={dia.key} className="total-day-column"><h3 className="total-day-title">{dia.label}</h3>{HORAS_TRABALHO.map(hora => (<div key={hora} className="total-time-slot"><strong>{hora}</strong><div className="available-psis-list">{totalSchedule[dia.key][hora].length > 0 ? ( totalSchedule[dia.key][hora].map(psiId => ( <span key={psiId} className="psi-badge">ID: {psiId}</span> )) ) : ( <span className="no-psis">Indisponível</span> )}</div></div>))}</div>))}</div>);
+    return (<div className="total-schedule-grid">{DIAS_SEMANA.map(dia => (<div key={dia.key} className="total-day-column"><h3 className="total-day-title">{dia.label}</h3>{HORAS_TRABALHO.map(hora => (<div key={hora} className="total-time-slot"><strong>{hora}</strong><div className="available-psis-list">{totalSchedule[dia.key][hora].length > 0 ? ( totalSchedule[dia.key][hora].map(psi => ( <span key={psi.id} className="psi-badge">{psi.nome}</span> )) ) : ( <span className="no-psis">Indisponível</span> )}</div></div>))}</div>))}</div>);
 };
 
 export default TotalScheduleView;


### PR DESCRIPTION
- Display psychologist names instead of IDs in the general schedule grid.
- Update eye icon in individual schedules to reflect expansion state (Eye for expanded, EyeOff for collapsed).